### PR TITLE
Fix: Add contentType to upload

### DIFF
--- a/src/utils/upload.ts
+++ b/src/utils/upload.ts
@@ -15,6 +15,7 @@ const upload = multer({
   storage: multerS3({
     s3,
     bucket: "figdiff",
+    contentType: multerS3.AUTO_CONTENT_TYPE,
     key: (req, file, cb) => {
       const uniqueKey = `${Date.now().toString()}-${uuidv4()}-${file.originalname}`;
 


### PR DESCRIPTION
### FigDiff

## 칸반 외 작업

## Description

- S3 링크가 이미지 다운로드 링크를 띄우는 문제 해결을 위해 contentType을 명시해줍니다

## Concern (필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지 (필요시)
