### PR TITLE
Feat: progress endpoint to include optionalData in response

### DIFF
--- a/src/controllers/figmaData.controller.ts
+++ b/src/controllers/figmaData.controller.ts
@@ -230,13 +230,12 @@ const figmaDataController = async (
 
     const imagesArray = await fetchFigmaPng(fileKey, newNodeId, accessToken);
 
-    updateProgress(100, "분석 완료하였습니다!");
+    updateProgress(100, "분석 완료하였습니다!", annotatedImageBuffer);
 
     res.status(200).send({
       figmaWidth,
       figmaHeight,
       imagesArray,
-      annotatedImageBuffer,
       screenshotBuffer,
       differentFigmaNodes,
     });

--- a/src/routes/progressBarSSE.ts
+++ b/src/routes/progressBarSSE.ts
@@ -4,6 +4,7 @@ const router = express.Router();
 
 let progress = 0;
 let stage = "분석 준비중입니다";
+let optionalData: Buffer | null = null;
 
 router.get("/progress", (req, res) => {
   res.setHeader("Content-Type", "text/event-stream");
@@ -11,7 +12,7 @@ router.get("/progress", (req, res) => {
   res.setHeader("Connection", "keep-alive");
 
   const sendProgress = () => {
-    res.write(`data: ${JSON.stringify({ progress, stage })}\n\n`);
+    res.write(`data: ${JSON.stringify({ progress, stage, optionalData })}\n\n`);
   };
 
   const interval = setInterval(sendProgress, 1000);
@@ -22,9 +23,18 @@ router.get("/progress", (req, res) => {
   });
 });
 
-export const updateProgress = (newProgress: number, newStage: string) => {
+export const updateProgress = (
+  newProgress: number,
+  newStage: string,
+  newOptionalData?: Buffer,
+) => {
   progress = newProgress;
   stage = newStage;
+  if (newOptionalData) {
+    optionalData = newOptionalData;
+  } else {
+    optionalData = null;
+  }
 };
 
 export default router;


### PR DESCRIPTION
### FigDiff

## [[BE] add optionalData on ProgressBar SSE](https://yummy-saw-ada.notion.site/BE-add-optionalData-on-ProgressBar-SSE-6c559160d48142738d38fbdd1896f001)

## Todo

- [x] annotatedImage를 크롬익스텐션으로 보내줍니다.

## Description

- annotatedImage를 크롬익스텐션으로 보내줍니다.
- optionalData이 없을경우 null를 반환해줍니다.

## Concern (필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지 (필요시)
